### PR TITLE
Fix GitHub repository date sorting

### DIFF
--- a/Javascript/github.js
+++ b/Javascript/github.js
@@ -45,11 +45,15 @@ function sortRepos(property, order, text) {
         let valueA = a[property];
         let valueB = b[property];
 
-        // Ha dátumot rendezünk, akkor időbélyegként hasonlítjuk össze
-        if (property === "created" || property === "updated") {
-            // A pushed_at mezőt használjuk a legutolsó módosításra
-            valueA = new Date(a.pushed_at).getTime(); // Használjuk a pushed_at mezőt
-            valueB = new Date(b.pushed_at).getTime(); // Használjuk a pushed_at mezőt
+        // Ha dátumot rendezünk, akkor a megfelelő időbélyeggel hasonlítjuk össze
+        if (property === "created") {
+            // Létrehozás dátuma szerinti rendezés
+            valueA = new Date(a.created_at).getTime();
+            valueB = new Date(b.created_at).getTime();
+        } else if (property === "updated") {
+            // Utolsó módosítás dátuma szerinti rendezés
+            valueA = new Date(a.pushed_at).getTime();
+            valueB = new Date(b.pushed_at).getTime();
         } else {
             valueA = valueA.toLowerCase();
             valueB = valueB.toLowerCase();


### PR DESCRIPTION
## Summary
- ensure `sortRepos` uses `created_at` for creation sorting and `pushed_at` for update sorting

## Testing
- `node - <<'NODE'
const repos=[
  {name:'repo1', created_at:'2020-01-01T00:00:00Z', pushed_at:'2020-01-02T00:00:00Z'},
  {name:'repo2', created_at:'2021-01-01T00:00:00Z', pushed_at:'2021-01-02T00:00:00Z'},
  {name:'repo3', created_at:'2019-01-01T00:00:00Z', pushed_at:'2019-01-02T00:00:00Z'}
];
function sortRepos(property, order){
  return repos.slice().sort((a,b)=>{
    let valueA=a[property];
    let valueB=b[property];
    if(property==='created'){
      valueA=new Date(a.created_at).getTime();
      valueB=new Date(b.created_at).getTime();
    }else if(property==='updated'){
      valueA=new Date(a.pushed_at).getTime();
      valueB=new Date(b.pushed_at).getTime();
    } else {
      valueA=valueA.toLowerCase();
      valueB=valueB.toLowerCase();
    }
    return order==='asc'? (valueA>valueB?1:-1):(valueA<valueB?1:-1);
  });
}
console.log('created asc',sortRepos('created','asc').map(r=>r.name));
console.log('created desc',sortRepos('created','desc').map(r=>r.name));
console.log('updated asc',sortRepos('updated','asc').map(r=>r.name));
console.log('updated desc',sortRepos('updated','desc').map(r=>r.name));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68a8d8d7a994832db2675331f640d8c7