### PR TITLE
fix: rename homepage title to DERDAWEB

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,14 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-    <meta property="og:title" content="Dominik Derda - WebPage">
+    <meta property="og:title" content="DERDAWEB">
   <meta property="og:description" content="Nézd meg a weboldalam!">
   <meta property="og:image" content="https://www.derdaweb.hu/Images/preview.png">
   <meta property="og:url" content="https://www.derdaweb.hu">
   <meta property="og:type" content="Website">
 		<meta charset="UTF-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<title>DHEARCDKA</title>
+                <title>DERDAWEB</title>
 		<link rel="stylesheet" href="Appearance/styles.css">
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.googleapis.com">


### PR DESCRIPTION
## Summary
- set homepage `<title>` to "DERDAWEB" to align with site-wide branding

## Testing
- `python - <<'PY'
import re
s=open('index.html').read()
print(re.search(r'<title>(.*?)</title>', s).group(1))
print(re.search(r'og:title" content="(.*?)"', s).group(1))
PY`
- `npx --yes htmlhint index.html`


------
https://chatgpt.com/codex/tasks/task_e_68a8d741bae4832db0fedd9d8f01722b